### PR TITLE
Fix relative import issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,6 @@ conda activate non-market-housing-dashboard
 Run the dashboard using Shiny with the following command:
 
 ```bash
-shiny run --reload --launch-browser src/app.py
+shiny run --reload --launch-browser src.app:app
 ```
+

--- a/src/app.py
+++ b/src/app.py
@@ -5,7 +5,7 @@ import pandas as pd
 from shapely import wkt
 from ipywidgets import HTML
 
-from charts.accessibility_pie import create_accessibility_pie_chart
+from .charts.accessibility_pie import create_accessibility_pie_chart
 
 clean_df = pd.read_csv(
     "data/processed/clean-non-market-housing.csv",


### PR DESCRIPTION
- Updated the import for `create_accessibility_pie_chart` to be a relative import (required as post connect views it as a package if not and the build fails)
- Updated the run command in `README.md` as the use of the old command with relative imports caused local builds to not work properly