### PR TITLE
Chat interface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ ANTHROPIC_API_KEY=your_anthropic_api_key_here
 
 # Google (Gemini) - https://aistudio.google.com/app/apikey
 # GOOGLE_API_KEY=your_google_api_key_here
+
+# GitHub Models - https://github.com/settings/tokens (use models scope)
+# GITHUB_TOKEN=your_github_pat_here

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# LLM API keys for the Assistant chat (set at least one)
+# Copy this file to .env and add your key(s)
+
+# Anthropic (Claude) - https://console.anthropic.com/account/keys
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# OpenAI (GPT) - https://platform.openai.com/api-keys
+# OPENAI_API_KEY=your_openai_api_key_here
+
+# Google (Gemini) - https://aistudio.google.com/app/apikey
+# GOOGLE_API_KEY=your_google_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -44,3 +44,14 @@ Run the dashboard using Shiny with the following command:
 ```bash
 shiny run --reload --launch-browser src.app:app
 ```
+
+### Assistant Chat (LLM)
+
+The Assistant tab uses an LLM for conversational help. To enable it:
+
+1. Copy `.env.example` to `.env`
+2. Add your API key for one provider:
+   - **Anthropic (Claude)**: `ANTHROPIC_API_KEY` from [console.anthropic.com](https://console.anthropic.com/account/keys)
+   - **OpenAI (GPT)**: `OPENAI_API_KEY` from [platform.openai.com](https://platform.openai.com/api-keys)
+   - **Google (Gemini)**: `GOOGLE_API_KEY` from [aistudio.google.com](https://aistudio.google.com/app/apikey)
+3. Restart the app

--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,7 @@ dependencies:
   - vl-convert-python=2.0.0
   - libsass=0.23.0
   - shapely=2.1.2
+  - pip
+  - pip:
+    - chatlas[anthropic,openai,google]
+    - python-dotenv>=1.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -17,5 +17,5 @@ dependencies:
   - shapely=2.1.2
   - pip
   - pip:
-    - chatlas[anthropic,openai,google]
+    - chatlas[anthropic,openai,google,github]
     - python-dotenv>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-﻿shiny==1.4
+shiny==1.4
 shinywidgets==0.7.1
+chatlas[anthropic,openai,google]
+python-dotenv>=1.0.0
 anywidget
 ipyleaflet==0.20
 pandas==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 shiny==1.4
 shinywidgets==0.7.1
-chatlas[anthropic,openai,google]
+chatlas[anthropic,openai,google,github]
 python-dotenv>=1.0.0
 anywidget
 ipyleaflet==0.20

--- a/src/app.py
+++ b/src/app.py
@@ -129,7 +129,25 @@ filters_sidebar = ui.sidebar(
 
 app_ui = ui.page_navbar(
     ui.nav_panel("Dashboard", ui.layout_sidebar(filters_sidebar, *dashboard_content, fillable=True)),
-    ui.nav_panel("Assistant", ui.card("Content for tab B")),
+    ui.nav_panel(
+        "Assistant",
+        ui.layout_columns(
+            ui.card(
+                ui.card_header("Assistant Output"),
+                ui.markdown("Results"),
+                style="height: 100%;",
+            ),
+            ui.chat_ui(
+                "assistant_chat",
+                messages=[
+                    "Hi! I'm your non-market housing assistant. Ask me anything about the data or how to use this dashboard."
+                ],
+            ),
+            col_widths=(8, 4),
+            fillable=True,
+        ),
+        value="assistant",
+    ),
     title="Non-Market Housing",
     fillable=True,
     theme=ui.Theme("lux"),
@@ -137,6 +155,12 @@ app_ui = ui.page_navbar(
 
 
 def server(input, output, session):
+    chat = ui.Chat(id="assistant_chat")
+
+    @chat.on_user_submit
+    async def handle_user_input(user_input: str):
+        # Simple echo response; can be extended with LLM or data-aware logic
+        await chat.append_message(f"You asked: {user_input}\n\nI'm a placeholder assistant. Connect me to an LLM or add custom logic to answer questions about the non-market housing data.")
 
     @reactive.calc
     def filtered_df():

--- a/src/app.py
+++ b/src/app.py
@@ -25,38 +25,7 @@ status_choices = {
                 }
 operator_choices = {v: v for v in sorted(clean_df["Operator"].dropna().unique())}
 
-app_ui = ui.page_sidebar(
-    ui.sidebar(
-        ui.input_selectize(
-            id="input_local_area",
-            label="Local Area",
-            choices=local_areas,
-            multiple=True,
-        ),
-        ui.input_checkbox_group(
-                id="input_status",
-                label="Project Status",
-                choices=status_choices,
-                selected=[]
-        ),
-        ui.input_selectize(
-            "input_operator",
-            "Operator",
-            operator_choices,
-            multiple=True
-        ),
-        ui.input_checkbox("input_occupied", "Include Unoccupied Projects", True),
-        ui.input_slider(
-                id="input_year",
-                label="Occupancy Year",
-                min=clean_df["Occupancy Year"].min(),
-                max=clean_df["Occupancy Year"].max(),
-                value=[clean_df["Occupancy Year"].min(), clean_df["Occupancy Year"].max()],
-                sep=""
-            ),
-        title="Filters",
-        bg="#f8f8f8",
-    ),
+dashboard_content = [
     ui.tags.style("""
     .accessibility-card,
     .accessibility-card .card-body,
@@ -124,8 +93,46 @@ app_ui = ui.page_sidebar(
         col_widths=(12, 12),
         row_heights=(2, 3),
     ),
+]
+
+filters_sidebar = ui.sidebar(
+    ui.input_selectize(
+        id="input_local_area",
+        label="Local Area",
+        choices=local_areas,
+        multiple=True,
+    ),
+    ui.input_checkbox_group(
+            id="input_status",
+            label="Project Status",
+            choices=status_choices,
+            selected=[]
+    ),
+    ui.input_selectize(
+        "input_operator",
+        "Operator",
+        operator_choices,
+        multiple=True
+    ),
+    ui.input_checkbox("input_occupied", "Include Unoccupied Projects", True),
+    ui.input_slider(
+            id="input_year",
+            label="Occupancy Year",
+            min=clean_df["Occupancy Year"].min(),
+            max=clean_df["Occupancy Year"].max(),
+            value=[clean_df["Occupancy Year"].min(), clean_df["Occupancy Year"].max()],
+            sep=""
+        ),
+    title="Filters",
+    bg="#f8f8f8",
+)
+
+app_ui = ui.page_navbar(
+    ui.nav_panel("Dashboard", ui.layout_sidebar(filters_sidebar, *dashboard_content, fillable=True)),
+    ui.nav_panel("Assistant", ui.card("Content for tab B")),
+    title="Non-Market Housing",
     fillable=True,
-    theme=ui.Theme("lux")
+    theme=ui.Theme("lux"),
 )
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -4,9 +4,13 @@ from shinywidgets import output_widget, render_widget, render_altair
 import pandas as pd
 from shapely import wkt
 from ipywidgets import HTML
+from dotenv import load_dotenv
+
+load_dotenv()
 
 from .charts.accessibility_pie import create_accessibility_pie_chart
 from .charts.clientele_bar_chart import make_clientele_bar_chart
+from .llm_client import create_chat_client
 from .charts.occupancy_line_chart import make_occupancy_line_chart
 
 clean_df = pd.read_csv(
@@ -156,11 +160,22 @@ app_ui = ui.page_navbar(
 
 def server(input, output, session):
     chat = ui.Chat(id="assistant_chat")
+    chat_client = create_chat_client()
 
     @chat.on_user_submit
     async def handle_user_input(user_input: str):
-        # Simple echo response; can be extended with LLM or data-aware logic
-        await chat.append_message(f"You asked: {user_input}\n\nI'm a placeholder assistant. Connect me to an LLM or add custom logic to answer questions about the non-market housing data.")
+        if chat_client is None:
+            await chat.append_message(
+                "No LLM provider configured."
+            )
+            return
+        try:
+            response = await chat_client.stream_async(user_input)
+            await chat.append_message_stream(response)
+        except Exception as e:
+            await chat.append_message(
+                f"Sorry, an error occurred: {str(e)}."
+            )
 
     @reactive.calc
     def filtered_df():

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -3,7 +3,7 @@ import os
 
 
 def create_chat_client():
-    """Create chatlas client from ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY in .env."""
+    """Create chatlas client from ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_API_KEY, or GITHUB_TOKEN in .env."""
     system_prompt = (
         # TODO: Update
         "You are a helpful assistant for a non-market housing dashboard in Vancouver. "
@@ -25,6 +25,12 @@ def create_chat_client():
         from chatlas import ChatGoogle
         return ChatGoogle(
             model="gemini-3.1-flash-lite-preview",
+            system_prompt=system_prompt,
+        )
+    if os.getenv("GITHUB_TOKEN"):
+        from chatlas import ChatGithub
+        return ChatGithub(
+            model="openai/gpt-4o-mini",
             system_prompt=system_prompt,
         )
     return None

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -1,0 +1,30 @@
+"""LLM chat client factory - uses first available provider from .env."""
+import os
+
+
+def create_chat_client():
+    """Create chatlas client from ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY in .env."""
+    system_prompt = (
+        # TODO: Update
+        "You are a helpful assistant for a non-market housing dashboard in Vancouver. "
+        "Help users understand the data, filters, and visualizations. Be concise and informative."
+    )
+    if os.getenv("ANTHROPIC_API_KEY"):
+        from chatlas import ChatAnthropic
+        return ChatAnthropic(
+            model="claude-haiku-4-5-20251001",
+            system_prompt=system_prompt,
+        )
+    if os.getenv("OPENAI_API_KEY"):
+        from chatlas import ChatOpenAI
+        return ChatOpenAI(
+            model="gpt-5-nano",
+            system_prompt=system_prompt,
+        )
+    if os.getenv("GOOGLE_API_KEY"):
+        from chatlas import ChatGoogle
+        return ChatGoogle(
+            model="gemini-3.1-flash-lite-preview",
+            system_prompt=system_prompt,
+        )
+    return None


### PR DESCRIPTION
- Closes #75 
- Adds an assistant tab to the dashboard with a shiny chat component and a blank results card (the LLM filtered results go here)
- Configured the chat component to use chatlas for the llm provider config
- Refer to the `env.local.` file on instructions for the `.env` setup to get the chat working locally